### PR TITLE
[FIX] Preflight auth

### DIFF
--- a/guidelight/client.py
+++ b/guidelight/client.py
@@ -164,15 +164,12 @@ class Client(object):
         query: dict = None,
         require_authentication: bool = True,
     ) -> dict:
-        self._pre_flight(require_authentication=require_authentication)
-        headers = self._request_headers
+        headers = self._pre_flight(require_authentication=require_authentication)
         url = self._make_endpoint(*endpoint, query=query)
 
         logger.debug(f"GET {repr(url)}")
 
-        rep = self.session.get(
-            str(url), headers=headers, timeout=self.timeout
-        )
+        rep = self.session.get(str(url), headers=headers, timeout=self.timeout)
 
         return self.handle(rep)
 
@@ -183,8 +180,7 @@ class Client(object):
         query: dict = None,
         require_authentication: bool = True,
     ) -> dict:
-        self._pre_flight(require_authentication=require_authentication)
-        headers = self._request_headers
+        headers = self._pre_flight(require_authentication=require_authentication)
         url = self._make_endpoint(*endpoint, query=query)
 
         logger.debug(f"POST {repr(url)}")
@@ -202,8 +198,7 @@ class Client(object):
         query: dict = None,
         require_authentication: bool = True,
     ) -> dict:
-        self._pre_flight(require_authentication=require_authentication)
-        headers = self._request_headers
+        headers = self._pre_flight(require_authentication=require_authentication)
         url = self._make_endpoint(*endpoint, query=query)
 
         logger.debug(f"PUT {repr(url)}")
@@ -220,15 +215,12 @@ class Client(object):
         query: dict = None,
         require_authentication: bool = True,
     ) -> dict:
-        self._pre_flight(require_authentication=require_authentication)
-        headers = self._request_headers
+        headers = self._pre_flight(require_authentication=require_authentication)
         url = self._make_endpoint(*endpoint, query=query)
 
         logger.debug(f"DELETE {repr(url)}")
 
-        rep = self.session.delete(
-            str(url), headers=headers, timeout=self.timeout
-        )
+        rep = self.session.delete(str(url), headers=headers, timeout=self.timeout)
 
         return self.handle(rep)
 
@@ -309,15 +301,16 @@ class Client(object):
     def _make_endpoint(self, *endpoint: tuple[str], query: dict = None) -> URL:
         return self.url.resolve("/", "v1", *endpoint, query=query)
 
-    def _pre_flight(self, require_authentication: bool = True) -> None:
+    def _pre_flight(self, require_authentication: bool = True) -> dict[str, str]:
         if not self.url:
             raise ClientError("no Endeavor URL has been configured")
 
-        self._request_headers = {}
-        self._request_headers.update(self._headers)
+        request_headers = {}
+        request_headers.update(self._headers)
 
         if require_authentication:
-            self._request_headers.update(self._authentication_headers())
+            request_headers.update(self._authentication_headers())
+        return request_headers
 
     def _authentication_headers(self) -> dict[str, str]:
         if not self.is_authenticated():

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,3 +5,4 @@ pyflakes==3.4.0
 pytest-cov==7.0.0
 pytest-flakes==4.0.5
 pytest-spec==5.1.0
+pytest-httpserver==1.1.3

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,32 @@
+from guidelight.client import Client
+from pytest_httpserver import HTTPServer
+
+
+def test_preflight():
+    """
+    Test preflight authentication happens implicitly.
+    """
+
+    # Create a test server
+    server = HTTPServer()
+    server.start()
+
+    # Expect authentication request
+    server.expect_request("/v1/authenticate").respond_with_json(
+        {
+            "access_token": "access",
+            "refresh_token": "refresh",
+        }
+    )
+
+    # Start a guidelight client
+    client = Client(
+        "http://localhost:%d" % server.port, client_id="id", client_secret="secret"
+    )
+
+    # Perform auth required request to trigger the preflight code
+    server.expect_request(
+        "/v1/authrequired",
+        headers={"Authorization": "Bearer access"},
+    ).respond_with_json([])
+    client.post({}, "/v1/authrequired")


### PR DESCRIPTION
### Scope of changes

This fixes a bug in the preflight auth logic to ensure that the credentials are actually being supplied in the header after an endpoint requires preflight authentication. Previously, the `self._request_headers` was being overwritten since the preflight function is actually called twice for the first request, so this changes it to a local variable.

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

[Copy acceptance criteria checklist from story for reviewer, or add a brief acceptance criteria here]

### Definition of Done

- [ ] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests
- [ ] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?