### PR TITLE
Specify an Authentication Endpoint

### DIFF
--- a/guidelight/__init__.py
+++ b/guidelight/__init__.py
@@ -25,7 +25,7 @@ from dotenv import load_dotenv
 from .client import Client
 
 
-def connect(url=None, client_id=None, client_secret=None, timeout=None):
+def connect(url=None, client_id=None, client_secret=None, auth_url=None, timeout=None):
     """
     Create an API client with the specified URL and api key material. If not specified,
     this function will first load any .env files in the local path, then attempt to
@@ -45,18 +45,27 @@ def connect(url=None, client_id=None, client_secret=None, timeout=None):
         The Client Secret from your API Key to access your Endeavor server. If not set,
         it is discovered from the $ENDEAVOR_CLIENT_SECRET environment variable.
 
+    auth_url : str
+        The URL of your authentication server (e.g. https://auth.guidelight.dev). If not
+        set, it is discovered from the $ENDEAVOR_AUTH_URL environment variable and falls
+        back to the url specified otherwise.
+
     timeout : float
         The number of seconds to wait for a response until error.
     """
 
-    if url is None or client_id is None or client_secret is None:
+    if url is None or client_id is None or client_secret is None or auth_url is None:
         # We need to load information from the environment
         load_dotenv()
 
     # create the client and perform the pre-flight now to authorize the client
     # now so the client's first actual data request isn't delayed by seconds
     client = Client(
-        url=url, client_id=client_id, client_secret=client_secret, timeout=timeout
+        url=url,
+        client_id=client_id,
+        client_secret=client_secret,
+        auth_url=auth_url,
+        timeout=timeout
     )
     client._pre_flight(require_authentication=True)
     return client


### PR DESCRIPTION
### Scope of changes

Allows users to specify an auth url to authenticate with Quarterdeck rather than relying on the Endeavor proxy. This is a temporary fix for the 503 proxy issue in Endeavor but will also mean that we can directly access Quarterdeck methods (e.g. for users and api keys) in the future, so it's an important addition.

Fixes SC-35451

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Does this fix the authentication issue?

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests
- [ ] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?